### PR TITLE
Fix signed to unsigned comparison warnings in generated code

### DIFF
--- a/src/ordt/output/cppmod/CppModBuilder.java
+++ b/src/ordt/output/cppmod/CppModBuilder.java
@@ -443,7 +443,7 @@ public class CppModBuilder extends OutputBuilder {
 		writeStmt(hppBw, 0, "int ordt_addr_elem_array<T>::write(const uint64_t &addr, const ordt_data &wdata) {");
 		//writeStmt(hppBw, 0, "   std::cout << \"addr_elem array write: ---- addr=\"<< addr << \", data=\" << wdata.to_string() << \"\\n\";");
 		writeStmt(hppBw, 0, "   if (this->containsAddress(addr)) {");
-		writeStmt(hppBw, 0, "      int idx = (addr - m_startaddress) / m_stride;");
+		writeStmt(hppBw, 0, "      uint64_t idx = (addr - m_startaddress) / m_stride;");
 		//writeStmt(hppBw, 0, "      std::cout << \"addr_elem array write: array contains addr=\" << addr << \" at idx=\" << idx << \"\\n\";");
 		writeStmt(hppBw, 0, "      if (idx < this->size()) return this->at(idx).write(addr, wdata);");
 		writeStmt(hppBw, 0, "   }");
@@ -458,7 +458,7 @@ public class CppModBuilder extends OutputBuilder {
 		writeStmt(hppBw, 0, "int ordt_addr_elem_array<T>::read(const uint64_t &addr, ordt_data &rdata) {");
 		//writeStmt(hppBw, 0, "   std::cout << \"addr_elem array read: ---- addr=\"<< addr << \", start=\" << m_startaddress << \", end=\" << m_endaddress<< \", stride=\" << m_stride<< \"\\n\";");
 		writeStmt(hppBw, 0, "   if (this->containsAddress(addr)) {");
-		writeStmt(hppBw, 0, "      int idx = (addr - m_startaddress) / m_stride;");
+		writeStmt(hppBw, 0, "      uint64_t idx = (addr - m_startaddress) / m_stride;");
 		//writeStmt(hppBw, 0, "      std::cout << \"addr_elem array read: array contains addr=\" << addr << \" at idx=\" << idx << \", array size=\" << this->size() << \"\\n\";");
 		writeStmt(hppBw, 0, "      if (idx < this->size()) return this->at(idx).read(addr, rdata);");
 		writeStmt(hppBw, 0, "   }");

--- a/src/ordt/output/cppmod/CppModClass.java
+++ b/src/ordt/output/cppmod/CppModClass.java
@@ -135,7 +135,7 @@ public class CppModClass extends CppBaseModClass {
 	   nMethod = newClass.addMethod(Vis.PUBLIC, "virtual void read(ordt_data &rdata)");  
 	   newClass.tagMethod("read", nMethod);  // tag this method so field info can be appended
 	   nMethod.addStatement("rdata.clear();");
-	   nMethod.addStatement("for (int widx=0; widx<((m_endaddress - m_startaddress + 1)/4); widx++) rdata.push_back(0);");
+	   nMethod.addStatement("for (uint64_t widx=0; widx<((m_endaddress - m_startaddress + 1)/4); widx++) rdata.push_back(0);");
 	   return newClass;
    }
 

--- a/src/ordt/output/drvmod/cpp/CppBaseModClass.java
+++ b/src/ordt/output/drvmod/cpp/CppBaseModClass.java
@@ -366,14 +366,14 @@ public class CppBaseModClass {
 		nMethod = newClass.addMethod(Vis.PUBLIC, "std::string to_string() const");
 		nMethod.addStatement("std::stringstream ss;");
 		nMethod.addStatement("ss << \"{\" << std::hex << std::showbase;");
-		nMethod.addStatement("for (int idx=this->size() - 1; idx >= 0; idx--) ");
+		nMethod.addStatement("for (size_t idx=this->size() - 1; idx >= 0; idx--) ");
 		nMethod.addStatement("   ss << \" \" << this->at(idx);");
 		nMethod.addStatement("ss << \" }\";");
 		nMethod.addStatement("return ss.str();");
 		
 		// = overload
 		nMethod = newClass.addMethod(Vis.PUBLIC, "ordt_data& operator=(const uint32_t rhs)");
-		//nMethod.addStatement("for (int idx=0; idx<this->size(); idx++) ");
+		//nMethod.addStatement("for (size_t idx=0; idx<this->size(); idx++) ");
 		//nMethod.addStatement("   this->at(idx) = rhs;");
 		nMethod.addStatement("   this->assign(this->size(), rhs);");
 		nMethod.addStatement("return *this;");
@@ -381,14 +381,14 @@ public class CppBaseModClass {
 		// ~ overload
 		nMethod = newClass.addMethod(Vis.PUBLIC, "ordt_data operator~()");
 		nMethod.addStatement("ordt_data temp;");
-		nMethod.addStatement("for (int idx=0; idx<this->size(); idx++) ");
+		nMethod.addStatement("for (size_t idx=0; idx<this->size(); idx++) ");
 		nMethod.addStatement("   temp.at(idx) = ~ this->at(idx);");
 		nMethod.addStatement("return temp;");
 		
 		// & overload
 		nMethod = newClass.addMethod(Vis.PUBLIC, "ordt_data operator&(const ordt_data& rhs)");
 		nMethod.addStatement("ordt_data temp;");
-		nMethod.addStatement("for (int idx=0; idx<this->size(); idx++) ");
+		nMethod.addStatement("for (size_t idx=0; idx<this->size(); idx++) ");
 		nMethod.addStatement("   if (idx < rhs.size()) temp.at(idx) = this->at(idx) & rhs.at(idx);");
 		nMethod.addStatement("   else temp.at(idx) = 0;");
 		nMethod.addStatement("return temp;");
@@ -396,7 +396,7 @@ public class CppBaseModClass {
 		// | overload
 		nMethod = newClass.addMethod(Vis.PUBLIC, "ordt_data operator|(const ordt_data& rhs)");
 		nMethod.addStatement("ordt_data temp;");
-		nMethod.addStatement("for (int idx=0; idx<this->size(); idx++) ");
+		nMethod.addStatement("for (size_t idx=0; idx<this->size(); idx++) ");
 		nMethod.addStatement("   if (idx < rhs.size()) temp.at(idx) = this->at(idx) | rhs.at(idx);");
 		nMethod.addStatement("   else temp.at(idx) = this->at(idx);");
 		nMethod.addStatement("return temp;");


### PR DESCRIPTION
- These are caused by using int as the iterator type in for loops rather than an unsigned type.
- Use size_t for iterator when comparing against the value returned by std library size() call.
- Use uint64_t when comparing against an address expression.
