### PR TITLE
Fix calculation of endaddress in cppmod ordt_addr_elem_array

### DIFF
--- a/src/ordt/output/cppmod/CppModBuilder.java
+++ b/src/ordt/output/cppmod/CppModBuilder.java
@@ -425,7 +425,7 @@ public class CppModBuilder extends OutputBuilder {
 
 		writeStmt(hppBw, 0, "template<typename T>");
 		writeStmt(hppBw, 0, "ordt_addr_elem_array<T>::ordt_addr_elem_array(uint64_t _m_startaddress, uint64_t _m_endaddress, int _reps, uint64_t _m_stride)");
-		writeStmt(hppBw, 0, "   : ordt_addr_elem(_m_startaddress, _m_endaddress + (_m_stride * _reps)), m_stride(_m_stride) {");
+		writeStmt(hppBw, 0, "   : ordt_addr_elem(_m_startaddress, _m_endaddress + (_m_stride * (_reps - 1))), m_stride(_m_stride) {");
 		writeStmt(hppBw, 0, "   this->reserve(_reps);");
 		writeStmt(hppBw, 0, "   uint64_t el_startaddress = _m_startaddress;");
 		writeStmt(hppBw, 0, "   uint64_t el_endaddress = _m_endaddress;");


### PR DESCRIPTION
When constructed, the startaddress and endaddress of an ordt_addr_elem_array
instance are the start and end addresses of a single element. In the
initializer of the ordt_addr_elem base class, the endaddress of the whole
array was calculated by adding the stride times the number of reps to the
endaddress passed in. This caused the endaddress of the array to be 1 element
beyond the end of the array, since the first element was already accounted
for. The fix is to add the stride times the reps minus 1.